### PR TITLE
fix: adopt forward-compatible approach to `builder:watch`

### DIFF
--- a/src/modules/router.ts
+++ b/src/modules/router.ts
@@ -1,3 +1,4 @@
+import { relative, resolve } from 'node:path'
 import defu from 'defu'
 import serialize from 'serialize-javascript'
 import { addTemplate, defineNuxtModule, importModule, resolvePath, useLogger } from '@nuxt/kit'
@@ -68,6 +69,7 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     nuxt.hook('builder:watch', async (event, path) => {
+      path = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, path))
       const pathPattern = new RegExp(`^(${routerFilePath}|${nuxt.options.srcDir}/views)/`)
       if (event !== 'change' && path.match(pathPattern)) {
         await nuxt.callHook('builder:generateApp')


### PR DESCRIPTION
We are planning to move to [emitting absolute paths in `builder:watch` in Nuxt v4](https://github.com/nuxt/nuxt/issues/25339). You can see a little more about the history in the PR linked in that issue.

This PR is an attempt to use a forward/backward compatible approach, namely resolving the path to ensure it's absolute, then making it relative so your existing code will continue to work.

This should be safe to merge as is, but do let me know if you have any concerns about this approach.

